### PR TITLE
pino logger transport issue fix when logging level is not debug

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-micro/common",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Shared utility functions for configuration management and common operations within the microservice framework.",
   "repository": {
     "type": "git",

--- a/packages/common/src/Logger.js
+++ b/packages/common/src/Logger.js
@@ -1,16 +1,25 @@
 const pino = require('pino');
 const os = require('os');
+const path = require('path');
+const fs = require('fs');
 
 class Logger {
   constructor(config) {
+    const logDir = path.join(process.cwd(), 'logs');
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir, { recursive: true });
+    }
+
     const transport = {
+      target: 'pino/file',
       options: {
         translateTime: 'yyyy-mm-dd HH:MM:ss Z',
         ignore: 'pid,hostname',
+        destination: path.join(logDir, 'app.log'),
       },
     }
 
-    const redaction = Array.isArray(config.logging.redaction)
+    const redaction = Array.isArray(config.logging?.redaction)
       ? config.logging.redaction.map((path) => `req.headers["${path.trim()}"]`)
       : [];
 
@@ -19,6 +28,7 @@ class Logger {
     if (config.logging.level === 'debug') {
       transport.target = 'pino-pretty'
       transport.colorize = true
+      delete transport.options.destination
     }
 
     this.logger = pino({


### PR DESCRIPTION
# Pull Request

## Description

@node-micro/common package throwing an error when logging level is not debug.

## Related Issue

Pino logging target and destination was missing when logging level is not debug in the config file.

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [x] All new and existing tests pass locally.
- [x] My code follows the style guidelines of this project.

## Screenshots (if applicable)

## Additional Notes
